### PR TITLE
Reinstated test logging and added another readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,21 @@ var actualResult = mockedCache.GetOrAdd(cacheEntryKey, () => expectedResult, Dat
 Assert.AreEqual(expectedResult, actualResult);
 ```
 
-Provided your SUT populates the cache that'd be all you need to do. If it doesn't, or you like your arrange to be verbose, use `SetUpCacheEntry<T>` to set up a cache entry:
+If your SUT populates the cache you're done. If it doesn't, or you like your arrange to be verbose, populate it as if you were using the real thing: 
+
+```c#
+var cacheEntryKey = "SomethingInTheCache";
+var expectedResult = Guid.NewGuid().ToString();
+
+var mockedCache = Create.MockedCachingService();
+mockedCache.Add(cacheEntryKey, expectedResult);
+
+var actualResult = mockedCache.Get<string>(cacheEntryKey);
+
+Assert.AreEqual(expectedResult, actualResult);
+```
+
+Or use the provided `SetUpCacheEntry<T>` extension method:
 
 ```c#
 var cacheEntryKey = "SomethingInTheCache";

--- a/src/LazyCache.Testing.Common.Tests/TestBase.cs
+++ b/src/LazyCache.Testing.Common.Tests/TestBase.cs
@@ -12,7 +12,7 @@ namespace LazyCache.Testing.Common.Tests
         [SetUp]
         public virtual void SetUp()
         {
-            LoggerHelper.LoggerFactory.AddConsole(LogLevel.Debug);
+            LoggerHelper.LoggerFactory = new LoggerFactory().AddConsole(LogLevel.Debug);
         }
 
         protected static readonly ILogger<TestBase> Logger = LoggerHelper.CreateLogger<TestBase>();

--- a/src/LazyCache.Testing.Moq.PackageVerification.Tests/ReadmeTests.cs
+++ b/src/LazyCache.Testing.Moq.PackageVerification.Tests/ReadmeTests.cs
@@ -16,7 +16,7 @@ namespace LazyCache.Testing.Moq.PackageVerification.Tests
         {
             LoggerHelper.LoggerFactory = LoggerFactory.Create(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Debug));
         }
-        
+
         [Test]
         public void Example1()
         {
@@ -37,7 +37,7 @@ namespace LazyCache.Testing.Moq.PackageVerification.Tests
             var expectedResult = Guid.NewGuid().ToString();
 
             var mockedCache = Create.MockedCachingService();
-            mockedCache.SetUpCacheEntry(cacheEntryKey, expectedResult);
+            mockedCache.Add(cacheEntryKey, expectedResult);
 
             var actualResult = mockedCache.Get<string>(cacheEntryKey);
 
@@ -46,6 +46,20 @@ namespace LazyCache.Testing.Moq.PackageVerification.Tests
 
         [Test]
         public void Example3()
+        {
+            var cacheEntryKey = "SomethingInTheCache";
+            var expectedResult = Guid.NewGuid().ToString();
+
+            var mockedCache = Create.MockedCachingService();
+            mockedCache.SetUpCacheEntry(cacheEntryKey, expectedResult);
+
+            var actualResult = mockedCache.Get<string>(cacheEntryKey);
+
+            Assert.AreEqual(expectedResult, actualResult);
+        }
+
+        [Test]
+        public void Example4()
         {
             var cacheEntryKey = "SomethingInTheCache";
             var expectedResult = Guid.NewGuid().ToString();

--- a/src/LazyCache.Testing.Moq.PackageVerification.Tests/ReadmeTests.cs
+++ b/src/LazyCache.Testing.Moq.PackageVerification.Tests/ReadmeTests.cs
@@ -1,6 +1,8 @@
 using System;
+using LazyCache.Testing.Common.Helpers;
 using LazyCache.Testing.Moq.Extensions;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
 
@@ -9,6 +11,12 @@ namespace LazyCache.Testing.Moq.PackageVerification.Tests
     [TestFixture]
     public class ReadmeTests
     {
+        [SetUp]
+        public void SetUp()
+        {
+            LoggerHelper.LoggerFactory = LoggerFactory.Create(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Debug));
+        }
+        
         [Test]
         public void Example1()
         {

--- a/src/LazyCache.Testing.NSubstitute.PackageVerification.Tests/ReadmeTests.cs
+++ b/src/LazyCache.Testing.NSubstitute.PackageVerification.Tests/ReadmeTests.cs
@@ -1,6 +1,8 @@
 using System;
+using LazyCache.Testing.Common.Helpers;
 using LazyCache.Testing.NSubstitute.Extensions;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -9,6 +11,12 @@ namespace LazyCache.Testing.NSubstitute.PackageVerification.Tests
     [TestFixture]
     public class ReadmeTests
     {
+        [SetUp]
+        public void SetUp()
+        {
+            LoggerHelper.LoggerFactory = LoggerFactory.Create(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Debug));
+        }
+        
         [Test]
         public void Example1()
         {

--- a/src/LazyCache.Testing.NSubstitute.PackageVerification.Tests/ReadmeTests.cs
+++ b/src/LazyCache.Testing.NSubstitute.PackageVerification.Tests/ReadmeTests.cs
@@ -16,7 +16,7 @@ namespace LazyCache.Testing.NSubstitute.PackageVerification.Tests
         {
             LoggerHelper.LoggerFactory = LoggerFactory.Create(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Debug));
         }
-        
+
         [Test]
         public void Example1()
         {
@@ -37,7 +37,7 @@ namespace LazyCache.Testing.NSubstitute.PackageVerification.Tests
             var expectedResult = Guid.NewGuid().ToString();
 
             var mockedCache = Create.MockedCachingService();
-            mockedCache.SetUpCacheEntry(cacheEntryKey, expectedResult);
+            mockedCache.Add(cacheEntryKey, expectedResult);
 
             var actualResult = mockedCache.Get<string>(cacheEntryKey);
 
@@ -46,6 +46,20 @@ namespace LazyCache.Testing.NSubstitute.PackageVerification.Tests
 
         [Test]
         public void Example3()
+        {
+            var cacheEntryKey = "SomethingInTheCache";
+            var expectedResult = Guid.NewGuid().ToString();
+
+            var mockedCache = Create.MockedCachingService();
+            mockedCache.SetUpCacheEntry(cacheEntryKey, expectedResult);
+
+            var actualResult = mockedCache.Get<string>(cacheEntryKey);
+
+            Assert.AreEqual(expectedResult, actualResult);
+        }
+
+        [Test]
+        public void Example4()
         {
             var cacheEntryKey = "SomethingInTheCache";
             var expectedResult = Guid.NewGuid().ToString();


### PR DESCRIPTION
Reinstated logging in the package verification projects
Made common logger factory creation explicit
Added another example to the readme for populating the cache